### PR TITLE
DOCS-1125: Migrating 2 docs for self-hosted Checkout

### DIFF
--- a/populate-order.mdx
+++ b/populate-order.mdx
@@ -1,0 +1,452 @@
+---
+title: Initialize, Populate, and Process a Checkout Order
+unlisted: true
+---
+
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
+When a customer is ready to check out, you can kick off the checkout process by [initializing an order](/api/orders#operation/InitializeOrder). The request body of this endpoint is flexible — you can leave it blank and populate it later, or use dynamic data from the platform to provide information about the cart and customer.
+
+This page leads you through the process of initializing, populating, and processing an order through the following API calls:
+
+1. [Initialize the order](/guides/checkout/populate-order#initialize-the-order)
+1. [Add items](/guides/checkout/populate-order#add-items)
+1. [Add a guest or authenticated customer](/guides/checkout/populate-order#add-customer)
+1. [Set the shipping address](/guides/checkout/populate-order#set-the-shipping-address)
+1. [Set the shipping line](/guides/checkout/populate-order#set-the-shipping-line)
+1. [Set the billing address](/guides/checkout/populate-order#set-the-billing-address)
+1. [Apply a discount, if applicable](/guides/checkout/populate-order#add-a-discount-code)
+1. [Generate taxes](/guides/checkout/populate-order#generate-taxes)
+1. [Get the iframe](/guides/checkout/populate-order#initialize-spi-and-add-payment)
+1. [Process the order](/guides/checkout/populate-order#process-order)
+
+:::note
+
+- There are various ways to call the Checkout Frontend API based on your business logic and checkout requirements. The instructions presented on this page are simply one recommendation.
+
+:::
+
+The following diagram shows a simplified example of how these calls might pass between the storefront and Bold Checkout:
+
+![A UML sequence diagram showing the architecture of Bold Checkout and actions required in each layer](/assets/images/guides/checkout/HeadlessCheckoutDiagram.png)
+
+## Prerequisites
+
+Before you get started, complete the steps outlined in the [Checkout Getting Started guide](/guides/checkout/checkout-getting-started).
+
+## Initialize the order
+
+When a customer clicks “Buy now”, “Checkout”, or any action that triggers the creation of a checkout page, the following steps are executed within the backend application:
+
+- (Optional) Receive cart information from the ecommerce platform.
+- (Optional) Authenticate the user.
+- Use the [Bold Checkout Backend API](/api/orders) to initialize an order.
+- Return the cart state to the frontend application in order to render the checkout.
+
+:::note
+
+These steps must be completed in your backend application because the [Initialize Order](/api/orders#operation/InitializeOrder) endpoint returns information that is not safe to share with the frontend, so it is important to make these calls from a controlled environment.
+
+:::
+
+The following sections contain instructions for completing each of these actions.
+
+### (Optional) Load dynamic cart data
+
+The [Initialize Order](/api/orders#operation/InitializeOrder) endpoint allows you to provide cart data through the `cart_items` object. This object can be left empty, explicitly defined, or populated with dynamic data.
+
+The methods for retrieving dynamic data to populate the request vary between platforms. You can retrieve a cart object or cart ID from your platform, which both allow you to populate the request body with the current customer's cart contents.
+
+You can also [add items to the cart later in the order lifecycle](/guides/checkout/populate-order#add-customer).
+
+### (Optional) Authenticate users
+
+If your store allows customers to log in to previously-created accounts, your backend application must verify the customer's identity while checking out.
+
+The [Initialize Order](/api/orders#operation/InitializeOrder) endpoint can accept a `customer` object in the request body. If the customer is logged in, use your platform's functionality to identify the customer checking out and verify this user is registered within your app. You can then use information from your platform, such as the `platform_id` of the customer, to construct a `customer` object and pass it to the Initialize Order endpoint.
+
+For example, BigCommerce provides a [Get Current Customer](https://developer.bigcommerce.com/api-reference/storefront/current-customers/current-customers/getcurrentcustomer) endpoint, which returns a JWT signed with your API access token. You can pass the JWT to your backend application and verify it matches your platform JWT, and determine the customer ID.
+
+If you determine that the customer is not logged in, you can treat the checkout as a guest checkout and omit the `customer` object from the Initialize Order request body.
+
+You can also [add an authenticated customer later in the order lifecycle](/guides/checkout/populate-order#add-items).
+
+### Call the Initialize Order endpoint
+
+Call the [Initialize Order](/api/orders#operation/InitializeOrder) endpoint of the Checkout Backend API to begin the checkout process.
+
+The JSON response to this call contains important information about the new order, including:
+
+- `initial_data` — a set of data about the store the order was created on.
+- `application_state` — all of the information that Bold Checkout has about the order. If no initial data was provided, all values will be empty.
+- `jwt_token` — a JSON Web Token (JWT) that authenticates the user’s checkout session.
+  :::note
+
+  The `jwt_token` must be used in the `Authentication: Bearer` header for all calls to the [Checkout Frontend API](/api/checkout). This token is valid for 60 minutes, after which it must be refreshed using the [Resume Order](/api/orders#operation/ResumeOrder) endpoint.
+
+  :::
+
+- `public_order_id` — a string used to keep track of the order and refresh the JWT if necessary.
+
+### Render the checkout
+
+After you call the [Initialize Order](/api/orders#operation/InitializeOrder) endpoint, you can display the checkout page to the customer. Because the Bold Checkout APIs are headless, you can do this via whatever frontend interface you would like.
+
+## Add items
+
+If you chose not to dynamically load cart data when you initialize an order, you can manually add line items to the order via the [Add Line Item](/api/checkout#operation/AddLineItem) endpoint.
+
+:::note
+
+- This endpoint requires either the `sku` or `platform_id` (also known as `platform_variant_id`) of the product to be added. These values can be found by calling any endpoint that deals with products or their variants, such as the [List Product Variants](/api/products#operation/ListProductVariants) endpoint.
+- The `line_item_key` is a user-defined unique identifier for each line item in the order. After you add the product to the order, you can later manipulate the line item using endpoints such as [Update Line Item](/api/checkout#operation/UpdateLineItem).
+
+:::
+
+The following cURL command demonstrates how to add an item to the order with this endpoint:
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/items"
+  token="{JWT}"
+  jsonData={{
+    platform_id: "71",
+    sku: "CLC",
+    quantity: 1,
+    line_item_key: "key1",
+  }}
+/>
+
+## Add customer
+
+If a customer is logged in when they enter the checkout flow, you can authenticate their identity using your platform and include their information in the [Initialize Order](/api/orders#operation/InitializeOrder) request body.
+
+However, if the customer does not have an account with your store or logs in later in the process, you can add a customer to an existing order. The following sections show you how to add a guest or authenticated customer after the order has already been created.
+
+### Add a guest customer
+
+The following cURL command demonstrates a call to the [Add Guest Customer](/api/checkout#operation/AddGuestCustomer) endpoint:
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/customer/guest"
+  token="{JWT}"
+  jsonData={{
+    first_name: "John",
+    last_name: "Doe",
+    email_address: "john.doe@example.com",
+    accepts_marketing: true,
+  }}
+/>
+
+### Add an authenticated customer
+
+The following cURL command demonstrates a call to the [Add Authenticated Customer](/api/orders#operation/AddAuthenticatedCustomer) endpoint. You can retrieve the customer's information from the platform or alternate user management system your store uses.
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/orders/{shop_identifier}/{public_order_id}/customer/authenticated"
+  token="{JWT}"
+  jsonData={{
+    first_name: "Jane",
+    last_name: "Doe",
+    email_address: "jane.doe@example.com",
+    platform_id: "string",
+    public_id: "string",
+    accepts_marketing: true,
+    saved_addresses: [
+      {
+        first_name: "Jane",
+        last_name: "Doe",
+        address_line_1: "50 Fultz Blvd",
+        address_line_2: "",
+        province: "Manitoba",
+        city: "Winnipeg",
+        country_code: "CA",
+        country: "Canada",
+        province_code: "MB",
+        postal_code: "R3Y0L6",
+        business_name: "",
+        phone_number: "800-555-0100",
+      },
+    ],
+  }}
+/>
+
+:::note
+
+If the customer is authenticated and has a saved address, you can populate their saved address in the UI and ask them to confirm the accuracy of the address. If they confirm it, you can then add the saved address as a shipping or billing address.
+
+:::
+
+## Set the shipping address
+
+Next, call the [Set Shipping Address](/api/checkout#operation/SetShippingAddress) endpoint. Complete this step before adding a shipping line and calculating taxes.
+
+The following cURL command demonstrates how to make this call:
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/addresses/shipping"
+  token="{JWT}"
+  jsonData={{
+    first_name: "John",
+    last_name: "Doe",
+    address_line_1: "50 Fultz Blvd",
+    address_line_2: "",
+    province: "Manitoba",
+    city: "Winnipeg",
+    country_code: "CA",
+    country: "Canada",
+    province_code: "MB",
+    postal_code: "R3Y0L6",
+    business_name: "",
+    phone_number: "800-555-0101",
+  }}
+/>
+
+## Set the shipping line
+
+_Shipping lines_ represent shipping methods that are available to your customers. You can configure shipping lines in the Bold Checkout app by navigating to **Shipping**, then **Shipping Zones**.
+
+Call the [List Shipping Lines](/api/checkout#operation/ListShippingLines) endpoint to determine the shipping lines that are available to your customer based on the shipping address they previously entered.
+
+The following cURL command demonstrates a call to this endpoint:
+
+<ExampleRequest
+  method="GET"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/shipping_lines"
+  token="{JWT}"
+/>
+
+Calling this endpoint populates the `available_shipping_lines` object in the order's `application_state` object.
+
+:::note
+
+If there is only one available shipping line, the `selected_shipping` object automatically populates with the shipping line details and you can skip the remainder of this section.
+
+:::
+
+When the customer selects how they would like their item to be shipped, use the `index` of the chosen shipping line to call the [Set Shipping Line](/api/checkout#operation/SetShippingLine) endpoint.
+
+The following cURL command demonstrates how to select the shipping line at an index of 0:
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/shipping_lines"
+  token="{JWT}"
+  jsonData={{
+    index: "0",
+  }}
+/>
+
+## Set the billing address
+
+Next, call the [Set Billing Address](/api/checkout#operation/SetBillingAddress) endpoint.
+
+:::note
+
+You might choose to include a checkbox that a customer can mark to indicate that their shipping and billing addresses are the same. If the customer marks the box, trigger the Set Billing Address endpoint using the address you previously collected.
+
+:::
+
+The following cURL command demonstrates an example of making this call:
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/addresses/billing"
+  token="{JWT}"
+  jsonData={{
+    id: "12",
+    first_name: "John",
+    last_name: "Doe",
+    address_line_1: "50 Fultz Blvd",
+    address_line_2: "",
+    province: "Manitoba",
+    city: "Winnipeg",
+    country_code: "CA",
+    country: "Canada",
+    province_code: "MB",
+    postal_code: "R3Y0L6",
+    business_name: "",
+    phone_number: "800-555-0102",
+  }}
+/>
+
+## Add a discount code
+
+The Checkout Frontend API enables you to validate, apply, or delete a discount code that was configured in the [Bold Checkout admin](https://apps.boldapps.net/accounts/app/4). Skip this step if your store does not have any discount codes or does not support them.
+
+### (Optional) Check validity
+
+While you are not required to check the validity of a discount code before you apply it, this step is useful if you want to implement custom error handling in a complicated discount code scenario. The [Validate Discount Code](/api/checkout#operation/ValidateDiscountCode) endpoint performs this validation.
+
+:::note
+
+This endpoint does not apply the discount code, only checks that it is valid.
+
+:::
+
+If the code is valid, the API returns an empty `data` array. If the discount code is not valid, the API returns the following error:
+
+```json
+{
+  "errors": [
+    {
+      "code": "02",
+      "type": "discount_code.discount_validation",
+      "message": "Could not find Discount: BFCM30"
+    }
+  ]
+}
+```
+
+### Apply the discount code
+
+Apply the code to the order using the [Add Discount Code](/api/checkout#operation/AddDiscountCode) endpoint. The following cURL command demonstrates an example of this call:
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/discounts"
+  token="{JWT}"
+  jsonData={{
+    code: "BFCM20",
+  }}
+/>
+
+## Generate taxes
+
+After you collect the customer's address and apply any price changes, calculate the applicable taxes. You cannot submit an order to be processed without first calling this endpoint and generating taxes.
+
+Configure your tax settings in the Bold Checkout app by clicking **Payment Options**, then **Tax Settings**. For more information, refer to [Set up Tax Settings in Bold Checkout](https://support.boldcommerce.com/hc/en-us/search?utf8=%E2%9C%93&query=Set+up+Tax+Settings+in+Bold+Checkout).
+
+When you are ready to calculate an order's taxes, call the [Generate Taxes](/api/checkout#operation/GenerateTaxes) endpoint. The following cURL snippet shows an example of that call:
+
+<ExampleRequest method="POST" path="/checkout/storefront/{shop_identifier}/{public_order_id}/taxes" token="{JWT}" />
+
+:::note
+
+Taxes are _not_ recalculated automatically. If you make any changes to the shipping address (through [Update Shipping Address](/api/checkout#operation/UpdateShippingAddress) or [Delete Shipping Address](/api/checkout#operation/DeleteShippingAddress)) after you initially generate taxes, you must call the [Generate Taxes](/api/checkout#operation/GenerateTaxes) endpoint again to recalculate the taxes. Failing to do so could result in charging customers for taxes inaccurately.
+
+:::
+
+## Initialize SPI and add payment
+
+Bold uses a [Secure Payments Interface (SPI)](/guides/checkout/resources/glossary#secure-payments-interface-spi) to isolate customer payment information from the rest of the site. This information is displayed in an `<iframe>` on a customer-facing page.
+
+You must generate a new instance of the SPI for each order using a `shop_identifier`, `public_order_id`, and `jwt`.
+
+After the customer enters their payment information and confirms it, you must capture the payment information using the `PIGI_ADD_PAYMENT` action.
+
+For example, the following JavaScript snippet shows how you might take the information captured in the `<iframe>` and add a payment to the order:
+
+```javascript
+const iframeElement = document.querySelector("iframe#SPI");
+const iframeWindow = iframeElement.contentWindow;
+const action = { actionType: "PIGI_ADD_PAYMENT" };
+iframeWindow.postMessage(action, "*");
+```
+
+A full list of SPI actions and responses can be found in the [SPI API reference](/guides/checkout/references/checkout-spi-api).
+
+## Process order
+
+When the customer indicates that they are ready to complete the order, call the [Process Order](/api/checkout#operation/ProcessOrder) endpoint. This call triggers the backend processing of the order.
+
+When this command is called, Bold Checkout checks to ensure all components of the order are valid, including the following:
+
+- Taxes are calculated.
+- Inventory is still available for the chosen products.
+- Payment(s) are authorized.
+- Discounts are finalized and officially applied.
+
+If each of these checks passes, Bold Checkout sends the order to the platform to be processed there. If one of these checks does not pass, the endpoint returns an error with a message indicating which step failed.
+
+The following cURL command demonstrates an example of a call to process an order:
+
+<ExampleRequest
+  method="POST"
+  path="/checkout/storefront/{shop_identifier}/{public_order_id}/process_order"
+  token="{JWT}"
+/>
+
+This command adds a `payments` object to the `application_state` object. Note that value of the `status` key is `paid`, but that the `transactions` list is empty.
+
+The following snippet shows an example of the `payments` object:
+
+```json
+"payments": [
+    {
+        "value": 5400,
+        "amount": 54,
+        "lineText": "1111",
+        "tag": "Credit",
+        "driver": "stripe",
+        "merchant_account": "Stripe",
+        "gateway_id": 35212,
+        "step": "preAuthed",
+        "token": "cus_Kn0z9EBAiVxo2f",
+        "currency": "CAD",
+        "id": "ch_3K7QycC6rJ6JeBJ015WC5hb8",
+        "transaction_token": "ch_3K7QycC6rJ6JeBJ015WC5hb8",
+        "brand": "Visa",
+        "is_customer": false,
+        "public_payment_method_id": null,
+        "key": "PaymentByCreditCard:PaymentService;Final:91000",
+        "status": "paid",
+        "transactions": [],
+        "is_eligible_for_app_fee": true,
+        "has_app_fee_been_collected": false,
+        "application_fee_charged": 54,
+        "application_fee_tier_id": 25,
+        "order_to_bold_exchange_rate": 1.27864,
+        "order_to_bold_currency_id": 1,
+        "tier_id": 0,
+        "order_payment_type_id": 1,
+        "additional_information": "",
+        "initial_recurring_charge": false,
+        "recurring_charge": false,
+        "bold_customer_id": 23317222,
+        "sequence_number": 1,
+        "successful_preauth": true,
+        "message": "",
+        "error_details": [],
+        "created_at": "2021-12-16 20:54:03.305734",
+        "single_use_token": "tok_1K7QxhC6rJ6JeBJ0EgFwRoBI",
+        "is_3ds_enabled": false,
+        "client_secret": "",
+        "idempotent_key": "",
+        "first_four_digits": "",
+        "bin": "",
+        "expiry": "",
+        "gateway_transaction_no": "",
+        "avs_result": "",
+        "cvd_result": "",
+        "transaction_time": "205459",
+        "transaction_date": "20211216",
+        "reference_num": "",
+        "txn_time": "",
+        "authorization_code": "ch_3K7QycC6rJ6JeBJ015WC5hb8",
+        "extra_payment_data": {
+            "cof": "none"
+        }
+    }
+]
+```
+
+Call the [Get Application State](/api/checkout#operation/GetApplicationState) endpoint to see the `transactions` list populate with data, as you can see in the following example:
+
+```json
+"transactions": [
+    {
+        "transaction_id": "2_0",
+        "payment_transactions": [
+            "2_0_0"
+        ]
+    }
+]
+```
+
+## Next steps
+
+Once the you populate and process the order, you can proceed to fulfill it — for more information, refer to [Fulfill an Order](/guides/checkout/fulfill-order).

--- a/sdk-integrate.mdx
+++ b/sdk-integrate.mdx
@@ -1,0 +1,178 @@
+---
+title: Integrate the Payment SDK
+unlisted: true
+---
+
+Integrate Bold's Payment SDK with your store to combine your store's existing frontend with Bold's payment options and capabilities, including increased security for your customers' payment data.
+
+The Payment SDK is how your store communicates with Bold's payment service. For more information on how Bold handles payment data, refer to the [information flow overview](/guides/checkout/concepts/payment-information).
+
+Integrating the Payment SDK with your store is available only for self-hosted Bold Checkout. If you're using Bold-Hosted Checkout instead, use our one-page or three-page templates instead of integrating this SDK.
+
+Follow these steps to integrate the Payment SDK with your store's frontend.
+
+### Add the Javascript SDK
+
+Load the following Payment SDK script to the page where you want to load payment buttons, card fields, or both.
+
+```javascript
+<script src="https://static-eps.secure.boldcommerce.com/js/payments_sdk.js"></script>
+```
+
+### Create the div container
+
+Create HTML elements for where the buttons or card fields will be rendered. You will need to pass this when calling the Payment SDK functions.
+
+### Initialize the Bold Order
+
+Initialize a checkout order using the Bold [initialize order endpoint](https://developer.boldcommerce.com/api/orders#tag/Orders/operation/InitializeOrder).
+
+### Initialize the Bold Payment SDK instance
+
+Initialize a new `bold.Payments` instance. Make sure that this is only initiated once.
+
+```
+const boldPayments = new window.bold.Payments(initialData);
+```
+
+The Bold Payment SDK requires `initialData` with the following data.
+
+| Field            | Type   | Description                                                                     |
+| ---------------- | ------ | ------------------------------------------------------------------------------- |
+| group_label      | string | The platform ID of your store                                                   |
+| trace_id         | string | Any string to help with debugging the logs (we prefer to use `public_order_id`) |
+| eps_url          | string | Should be `https://eps.secure.boldcommerce.com`                                 |
+| eps_bucket_url   | string | Should be `https://static-eps.secure.boldcommerce.com`                          |
+| payment_gateways | Array  | The payment gateway information that is provided in the order init endpoint     |
+| callbacks        | Array  | See below for details                                                           |
+
+#### Callbacks
+
+The Payment SDK requires specific data from the the storefront to process the payment. These callbacks are defined by the storefront to work properly with the Payment SDK.
+
+1. `onClickPaymentOrder`: Calls when the user clicks on any payment buttons like Google Pay, Apple Pay, or Paypal.
+1. `onCreatePaymentOrder`: (PayPal Complete Payments only) Calls to create an order on the payment gateway side.
+1. `onUpdatePaymentOrder`: Calls when the user changes their shipping information on the digital wallet UI to get the updated taxes or shipping lines information.
+1. `onRequireOrderData`: Calls when the Payment SDK needs any specific data.
+1. `onApprovePaymentOrder`: Calls when the user clicks to complete the payment on the digital wallet UI.
+1. `onScaPaymentOrder`: Calls when the Payment SDK needs to handle the SCA.
+1. `onErrorPaymentOrder`: (Optional) Calls when there is any error reported by payment gateway.
+1. `onUpdateVisuals`: (Optional) Calls if there are any UI changes done by the Payment SDK.
+
+The following code shows an example of defining a callback function:
+
+```typescript
+export async function onRequireOrderData(requirements: Array<IRequirementDataType>):Promise<IOrderDataPayload> {
+    const appState = getApplicationState();
+
+    const dataPayload: IOrderDataPayload = {};
+    requirements.forEach(rq => {
+        switch (rq) {
+            case 'customer':
+                dataPayload[rq] = {
+                    first_name: appState.customer.first_name,
+                    last_name: appState.customer.last_name,
+                    email_address: appState.customer.email_address,
+                };
+                break;
+            case 'billing_address':
+                dataPayload[rq] = appState.addresses.billing;
+                break;
+            case 'shipping_address':
+                dataPayload[rq] = appState.addresses.shipping;
+                break;
+            ...
+        }
+    });
+
+    return dataPayload;
+}
+
+```
+
+### Render Methods
+
+On the new instance, call the render methods:
+
+1. [Render Payments](#render-payments)
+1. [Render Wallet Payments](#render-wallet-payments)
+
+#### Render Payments
+
+This method renders the digital wallets along with the credit card fields.
+
+Example:
+
+```typescript
+boldPayments
+  .renderPayments(divContainer)
+  .then(() => {
+    // handle anything that need to be done after payment iframe is shows
+  })
+  .catch((e: Error) => {
+    // do error handling here
+  });
+```
+
+![A screenshot of SPI Payment interface.](/assets/images/guides/checkout/spi_ui.png)
+
+After you initialize this function, complete the following steps.
+
+1. If the customer is using payment buttons, the next steps are handled by the the callbacks when customers interact with the buttons.
+1. If the customer is using card fields and they clicks to complete a payment, call `getDataRequirements` and `tokenize`. Example:
+
+```typescript
+const requirements = boldPayments.getDataRequirements();
+const dataPayload: ITokenizePayload = {};
+requirements.forEach(rq => {
+    switch (rq) {
+        case 'customer':
+           // provide customer information to dataPayload
+           break;
+        case 'billing_address':
+           // provide billing address to dataPayload
+            break;
+        case 'shipping_address':
+           // provide shipping address to dataPayload
+        break;
+ });
+
+boldPayments.tokenize(dataPayload).then(() => {
+    // call process order endpoint
+}).catch((e) => {
+    // do error handling
+});
+
+```
+
+#### Render Wallet Payments
+
+This method only renders the digital wallet buttons like Apple Pay, Google Pay, or Paypal.
+
+Example:
+
+```typescript
+boldPayments
+  .renderWalletPayments(divContainer)
+  .then(() => {
+    // handle anything that need to be done after payment iframe is shows
+  })
+  .catch((e: Error) => {
+    // do error handling here
+  });
+```
+
+![A screenshot of SPI Wallet Buttons.](/assets/images/guides/checkout/wallet_buttons.png)
+
+When customers interact with the buttons,the callbacks handle the next steps for digital wallet payments.
+
+### Implementing Strong Customer Authentication (SCA)
+
+If the merchant and customer are both located in Europe, you may be required to complete additional verification of the customer's identity to comply with Strong Customer Authentication (SCA). Bold completes this authentication using 3D Secure (3DS) technology, which is displayed within the SPI iframe.
+
+The following steps outline the process of successfully handling SCA on an order:
+
+1. The storefront calls the Process Order endpoint and receives a 202 error with a request body of `{"clientSecretToken": "token", }`.
+1. The storefront calls the EPS tokenize request with the `client_secret_token` as a payload to in the request.
+1. The Payment SDK shows the SCA in fullscreen.
+1. Once the request is done, the storefront retries the Process Order endpoint.


### PR DESCRIPTION
- Adds 2 pages formerly in the dev docs, since they make more sense here alongside the templates
- Pages: [Integrate the Payment SDK](https://developer.boldcommerce.com/guides/checkout/concepts/sdk-integrate) and [Initialize, Populate, and Process a Checkout Order](https://developer.boldcommerce.com/guides/checkout/populate-order)
- **Not ready for review.** Getting more info on product direction given our recent org changes. If we _do_ end up putting these here instead of floating in the dev docs, I need to give these another pass for updates and organize them better